### PR TITLE
chore: update dev deps to phpstan 2.x, WP 6.6-6.9 matrix, PHP 8.0+

### DIFF
--- a/.github/workflows/WP_6_6.yaml
+++ b/.github/workflows/WP_6_6.yaml
@@ -1,4 +1,4 @@
-name: WordPress 5.9 Test Suite [PHP7.2-8.1]
+name: WordPress 6.6 Test Suite [PHP8.0-8.4]
 
 on:
   push:
@@ -11,11 +11,10 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1']
-        mysql-versions: ['mysql:5.7', 'mariadb:10.7','mariadb:10.6','mariadb:10.5','mariadb:10.4','mariadb:10.3','mariadb:10.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions: ['mysql:9', 'mysql:8.4', 'mysql:8.0', 'mariadb:12', 'mariadb:11.8', 'mariadb:11.4', 'mariadb:11.2', 'mariadb:11.0', 'mariadb:10.11', 'mariadb:10.6']
     runs-on: ${{ matrix.operating-system }}
     services:
-      # Setup MYSQL
       mysql-service:
         image: ${{ matrix.mysql-versions }}
         env:
@@ -24,11 +23,11 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
           --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-  
+          --health-timeout=10s
+          --health-retries=10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,21 +44,21 @@ jobs:
 
       - name: Clear existing composer
         run: >
-          sudo rm -rf vendor 
-          && rm -rf composer.lock 
+          sudo rm -rf vendor
+          && rm -rf composer.lock
       - name: Validate composer.json and composer.lock
         run: composer validate
 
       - name: Install dependencies
         run: >
-          rm -rf composer.lock 
+          rm -rf composer.lock
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:5.9.0 --dev --no-update
-          && composer require roots/wordpress:5.9.4 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:5.9.4 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.6.* --dev --no-update
+          && composer require roots/wordpress:6.6.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.6.* --dev --no-update
           && composer update --no-cache
-      
-      - name: Run Tests on WP5.9
+
+      - name: Run Tests on WP6.6
         env:
           environment_github: true
         run: composer all

--- a/.github/workflows/WP_6_7.yaml
+++ b/.github/workflows/WP_6_7.yaml
@@ -1,0 +1,64 @@
+name: WordPress 6.7 Test Suite [PHP8.0-8.4]
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions: ['mysql:9', 'mysql:8.4', 'mysql:8.0', 'mariadb:12', 'mariadb:11.8', 'mariadb:11.4', 'mariadb:11.2', 'mariadb:11.0', 'mariadb:10.11', 'mariadb:10.6']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      mysql-service:
+        image: ${{ matrix.mysql-versions }}
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
+          --health-interval=10s
+          --health-timeout=10s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor
+          && rm -rf composer.lock
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.7.* --dev --no-update
+          && composer require roots/wordpress:6.7.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.7.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on WP6.7
+        env:
+          environment_github: true
+        run: composer all

--- a/.github/workflows/WP_6_8.yaml
+++ b/.github/workflows/WP_6_8.yaml
@@ -1,4 +1,4 @@
-name: WordPress 6.1 Test Suite [PHP7.2-8.1]
+name: WordPress 6.8 Test Suite [PHP8.0-8.4]
 
 on:
   push:
@@ -11,11 +11,10 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        mysql-versions: ['mysql:5.7', 'mariadb:10.7','mariadb:10.6','mariadb:10.5','mariadb:10.4','mariadb:10.3','mariadb:10.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions: ['mysql:9', 'mysql:8.4', 'mysql:8.0', 'mariadb:12', 'mariadb:11.8', 'mariadb:11.4', 'mariadb:11.2', 'mariadb:11.0', 'mariadb:10.11', 'mariadb:10.6']
     runs-on: ${{ matrix.operating-system }}
     services:
-      # Setup MYSQL
       mysql-service:
         image: ${{ matrix.mysql-versions }}
         env:
@@ -24,11 +23,11 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
           --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-  
+          --health-timeout=10s
+          --health-retries=10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,25 +44,21 @@ jobs:
 
       - name: Clear existing composer
         run: >
-          sudo rm -rf vendor 
-          && rm -rf composer.lock 
+          sudo rm -rf vendor
+          && rm -rf composer.lock
       - name: Validate composer.json and composer.lock
         run: composer validate
 
       - name: Install dependencies
         run: >
-          rm -rf composer.lock 
+          rm -rf composer.lock
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:6.0.0 --dev --no-update
-          && composer require roots/wordpress:6.1.1 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:6.1.1 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.8.* --dev --no-update
+          && composer require roots/wordpress:6.8.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.8.* --dev --no-update
           && composer update --no-cache
 
-      - name: Run Tests on Latest Version - WP6.0
+      - name: Run Tests on WP6.8
         env:
           environment_github: true
         run: composer all
-
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV }}
- 

--- a/.github/workflows/WP_6_9.yaml
+++ b/.github/workflows/WP_6_9.yaml
@@ -1,4 +1,4 @@
-name: WordPress 6.0 Test Suite [PHP7.2-8.1]
+name: WordPress 6.9 Test Suite [PHP8.0-8.4]
 
 on:
   push:
@@ -11,11 +11,10 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        mysql-versions: ['mysql:5.7', 'mariadb:10.7','mariadb:10.6','mariadb:10.5','mariadb:10.4','mariadb:10.3','mariadb:10.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions: ['mysql:9', 'mysql:8.4', 'mysql:8.0', 'mariadb:12', 'mariadb:11.8', 'mariadb:11.4', 'mariadb:11.2', 'mariadb:11.0', 'mariadb:10.11', 'mariadb:10.6']
     runs-on: ${{ matrix.operating-system }}
     services:
-      # Setup MYSQL
       mysql-service:
         image: ${{ matrix.mysql-versions }}
         env:
@@ -24,11 +23,11 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
           --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-  
+          --health-timeout=10s
+          --health-retries=10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,25 +44,28 @@ jobs:
 
       - name: Clear existing composer
         run: >
-          sudo rm -rf vendor 
-          && rm -rf composer.lock 
+          sudo rm -rf vendor
+          && rm -rf composer.lock
       - name: Validate composer.json and composer.lock
         run: composer validate
 
       - name: Install dependencies
         run: >
-          rm -rf composer.lock 
+          rm -rf composer.lock
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:6.0.0 --dev --no-update
-          && composer require roots/wordpress:6.0.0 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:6.0.0 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.9.* --dev --no-update
+          && composer require roots/wordpress:6.9.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.9.* --dev --no-update
           && composer update --no-cache
 
-      - name: Run Tests on Latest Version - WP6.0
+      - name: Run Tests on WP6.9
         env:
           environment_github: true
         run: composer all
 
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV }}
- 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.WPDB_MIGRATIONS_CODECOV }}
+          files: ./clover.xml
+          fail_ci_if_error: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,85 @@
+checks:
+    php:
+        code_rating: true
+        duplication: true
+        fix_php_opening_tag: false
+        remove_php_closing_tag: false
+        one_class_per_file: false
+        side_effects_or_types: false
+        no_mixed_inline_html: false
+        require_braces_around_control_structures: false
+        php5_style_constructor: false
+        no_global_keyword: false
+        avoid_usage_of_logical_operators: false
+        psr2_class_declaration: false
+        no_underscore_prefix_in_properties: false
+        no_underscore_prefix_in_methods: false
+        blank_line_after_namespace_declaration: false
+        single_namespace_per_use: false
+        psr2_switch_declaration: false
+        psr2_control_structure_declaration: false
+        avoid_superglobals: false
+        security_vulnerabilities: false
+        no_exit: false
+
+build:
+    dependencies:
+        override:
+            - 'composer install --no-interaction --prefer-dist'
+    nodes:
+        analysis:
+            project_setup:
+                override:
+                    - 'true'
+            tests:
+                override:
+                    - php-scrutinizer-run
+
+tools:
+    php_analyzer:
+        enabled: true
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'template/*', 'node_modules/*', 'vendor/*']
+        config:
+            checkstyle:
+                enabled: true
+                naming:
+                    isser_method_name: ^.*$
+                    utility_class_name: ^.*$
+            doc_comment_fixes:
+                enabled: false
+            reflection_fixes:
+                enabled: false
+            use_statement_fixes:
+                enabled: false
+            simplify_boolean_return:
+                enabled: true
+    php_changetracking: true
+    php_cpd: true
+    php_cs_fixer: false
+    php_mess_detector: true
+    php_pdepend: true
+    sensiolabs_security_checker: true
+
+filter:
+    paths:
+        - 'src/*'
+    excluded_paths:
+        - 'tests/*'
+        - 'docs/*'
+        - 'docs-gen/*'
+        - 'node_modules/*'
+        - 'vendor/*'
+        - 'template/*'
+
+coding_style:
+    php:
+        indentation:
+            general:
+                use_tabs: true
+                size: 4
+        spaces:
+            before_parentheses:
+                closure_definition: true
+            around_operators:
+                concatenation: true

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 System for creating database migrations with WordPress
 
-[![Latest Stable Version](http://poser.pugx.org/pinkcrab/wp-db-migrations/v)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![Total Downloads](http://poser.pugx.org/pinkcrab/wp-db-migrations/downloads)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![Latest Unstable Version](http://poser.pugx.org/pinkcrab/wp-db-migrations/v/unstable)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![License](http://poser.pugx.org/pinkcrab/wp-db-migrations/license)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![PHP Version Require](http://poser.pugx.org/pinkcrab/wp-db-migrations/require/php)](https://packagist.org/packages/pinkcrab/wp-db-migrations)
+[![Latest Stable Version](https://poser.pugx.org/pinkcrab/wp-db-migrations/v)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![Total Downloads](https://poser.pugx.org/pinkcrab/wp-db-migrations/downloads)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![Latest Unstable Version](https://poser.pugx.org/pinkcrab/wp-db-migrations/v/unstable)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![License](https://poser.pugx.org/pinkcrab/wp-db-migrations/license)](https://packagist.org/packages/pinkcrab/wp-db-migrations) [![PHP Version Require](https://poser.pugx.org/pinkcrab/wp-db-migrations/require/php)](https://packagist.org/packages/pinkcrab/wp-db-migrations)
 ![GitHub contributors](https://img.shields.io/github/contributors/Pink-Crab/WPDB_Migrations?label=Contributors)
 ![GitHub issues](https://img.shields.io/github/issues-raw/Pink-Crab/WPDB_Migrations)
-[![WordPress 5.9 Test Suite [PHP7.2-8.1]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_5_9.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_5_9.yaml)
-[![WordPress 6.0 Test Suite [PHP7.2-8.1]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_0.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_0.yaml)
-[![WordPress 6.1 Test Suite [PHP7.2-8.1]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_1.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_1.yaml)
+[![WordPress 6.6 Test Suite [PHP8.0-8.4]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_6.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_6.yaml)
+[![WordPress 6.7 Test Suite [PHP8.0-8.4]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_7.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_7.yaml)
+[![WordPress 6.8 Test Suite [PHP8.0-8.4]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_8.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_8.yaml)
+[![WordPress 6.9 Test Suite [PHP8.0-8.4]](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_9.yaml/badge.svg)](https://github.com/Pink-Crab/WPDB_Migrations/actions/workflows/WP_6_9.yaml)
 [![codecov](https://codecov.io/gh/Pink-Crab/WPDB_Migrations/branch/master/graph/badge.svg?token=WEZOLOURI1)](https://codecov.io/gh/Pink-Crab/WPDB_Migrations)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/WPDB_Migrations/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/WPDB_Migrations/?branch=master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a680395630683fd2f1e4/maintainability)](https://codeclimate.com/github/Pink-Crab/WPDB_Migrations/maintainability)
@@ -22,9 +23,9 @@ Requires PinkCrab Table Builder, Composer and WordPress.
 Uses the [WPDB Table Builder](https://github.com/Pink-Crab/WPDB-Table-Builder) library.
 
 > **TESTED AGAINST**
-> * PHP  7.2, 7.3, 7.4, 8.0 & 8.1
-> * Mysql 5.7, MariaDB 10.2, 10.3, 10.4, 10.5, 10.6 & 10.7
-> * WP5.9, WP6.0 & WP6.1
+> * PHP 8.0, 8.1, 8.2, 8.3 & 8.4
+> * MySQL 8.0, 8.4, 9 & MariaDB 10.6, 10.11, 11.0, 11.2, 11.4, 11.8, 12
+> * WP6.6, WP6.7, WP6.8 & WP6.9
 
 ****
 
@@ -182,6 +183,7 @@ Thanks to the Migration_Log, tables will only be reprocessed if the schema has c
 
 ---
 ## Change log
+* 1.0.5 - Updated dev deps, PHP 8.0+, phpstan 2.x, refreshed WP 6.6-6.9 test matrix.
 * 1.0.4 - Updated dependencies and testing pipeline
 * 1.0.3 - Improved exceptions 
 * 1.0.2 - Updated docs, added in means to clear all Logs from Log Manager and fixed a type with `Migration_Manager::migation_log()` (this method has been deprecated and replace with `Migration_Manager::migration_log()`)

--- a/composer.json
+++ b/composer.json
@@ -23,30 +23,29 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0",
-        "phpstan/phpstan": "^1.0",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "php-stubs/wordpress-stubs": "^6.0 || ^5.9",
-        "roots/wordpress": "^6.1",
-        "wp-phpunit/wp-phpunit": "^6.1",
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "phpstan/phpstan": "^2.0",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/wordpress-stubs": "6.9.*",
+        "roots/wordpress": "6.9.*",
+        "wp-phpunit/wp-phpunit": "6.9.*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*",
-        "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0",
+        "yoast/phpunit-polyfills": "^1.0.0 || ^2.0.0",
         "symfony/var-dumper": "*",
         "gin0115/wpunit-helpers": "~1",
         "vlucas/phpdotenv": "^5.4"
     },
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=8.0.0",
         "pinkcrab/table_builder": "1.2.*"
     },
     "scripts": {
-        "test": "phpunit --coverage-clover clover.xml --testdox  --colors=always",
-        "coverage": "phpunit --coverage-html coverage-report  --testdox --colors=always",
+        "test": "vendor/bin/phpunit --colors=always --testdox --coverage-clover clover.xml",
+        "coverage": "vendor/bin/phpunit --colors=always --testdox --coverage-html coverage-report",
         "analyse": "vendor/bin/phpstan analyse src -l8",
-        "sniff": "vendor/bin/phpcs src/ -v",
-        "all": "composer test && composer analyse && composer sniff"
-
+        "sniff": "./vendor/bin/phpcs src/ -v",
+        "all": "composer coverage && composer analyse && composer sniff"
     },
     "config": {
         "allow-plugins": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,6 +19,7 @@
 		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_close"/>
 		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder" />
 	</rule>
 
 	<!-- Add in some extra rules from other standards. -->

--- a/src/Database_Migration.php
+++ b/src/Database_Migration.php
@@ -101,5 +101,4 @@ abstract class Database_Migration {
 	public function get_table_name(): string {
 		return $this->table_name;
 	}
-
 }

--- a/src/Log/Migration_Log.php
+++ b/src/Log/Migration_Log.php
@@ -143,7 +143,8 @@ class Migration_Log {
 			'foreign_keys' => $schema->get_foreign_keys(),
 		);
 
-		return md5( \serialize( $export ) ?: $schema->get_table_name() );  // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize, Serialised to preserve types
+		$serialized = \serialize( $export );  // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Serialised to preserve types.
+		return md5( $serialized ? $serialized : $schema->get_table_name() );
 	}
 
 	/** GETTERS */

--- a/src/Log/Migration_Log_Manager.php
+++ b/src/Log/Migration_Log_Manager.php
@@ -45,7 +45,7 @@ class Migration_Log_Manager {
 	 */
 	protected $migration_details = array();
 
-	public function __construct( string $option_key = null ) {
+	public function __construct( ?string $option_key = null ) {
 		$this->option_key = $option_key ?? 'pinkcrab_migration_log';
 		$this->set_migration_details();
 	}

--- a/src/Migration_Exception.php
+++ b/src/Migration_Exception.php
@@ -53,7 +53,7 @@ class Migration_Exception extends Exception {
 	 * @param int $code
 	 * @param Throwable$previous
 	 */
-	public function __construct( Schema $schema, string $wpdb_error = '', $message = '', $code = 0, Throwable $previous = null ) {
+	public function __construct( Schema $schema, string $wpdb_error = '', $message = '', $code = 0, ?Throwable $previous = null ) {
 		parent::__construct( $message, $code, $previous );
 		$this->schema     = $schema;
 		$this->wpdb_error = $wpdb_error;

--- a/src/Migration_Manager.php
+++ b/src/Migration_Manager.php
@@ -64,7 +64,6 @@ class Migration_Manager {
 		$this->builder       = $builder;
 		$this->wpdb          = $wpdb;
 		$this->migration_log = new Migration_Log_Manager( $migration_log_key );
-
 	}
 
 	/**
@@ -121,7 +120,7 @@ class Migration_Manager {
 		// Remove excluded tables.
 		$to_create = array_filter(
 			$this->migrations,
-			function( Database_Migration $migration ) use ( $excluded_table ): bool {
+			function ( Database_Migration $migration ) use ( $excluded_table ): bool {
 				return ! in_array( $migration->get_table_name(), $excluded_table, true )
 				&& $this->migration_log->can_migrate( $migration->get_schema() );
 			}
@@ -136,7 +135,6 @@ class Migration_Manager {
 		}
 
 		return $this;
-
 	}
 
 	/**
@@ -150,7 +148,7 @@ class Migration_Manager {
 		// Remove excluded tables.
 		$to_seed = array_filter(
 			$this->migrations,
-			function( Database_Migration $migration ) use ( $excluded_table ): bool {
+			function ( Database_Migration $migration ) use ( $excluded_table ): bool {
 				return ! in_array( $migration->get_table_name(), $excluded_table, true )
 				&& ! $this->migration_log->is_seeded( $migration->get_schema() );
 			}
@@ -178,7 +176,7 @@ class Migration_Manager {
 		// Remove excluded tables.
 		$to_seed = array_filter(
 			$this->migrations,
-			function( Database_Migration $migration ) use ( $excluded_table ): bool {
+			function ( Database_Migration $migration ) use ( $excluded_table ): bool {
 				return ! in_array( $migration->get_table_name(), $excluded_table, true );
 			}
 		);
@@ -188,11 +186,13 @@ class Migration_Manager {
 			try {
 				$result = $this->builder->drop_table( $migration->get_schema() );
 			} catch ( Engine_Exception $th ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- internal exception message.
 				throw Migration_Exception::failed_to_drop_table( $migration->get_schema(), $th->getMessage() );
 			}
 
 			// Throw exception if fails.
 			if ( $result === false ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- internal exception message.
 				throw Migration_Exception::failed_to_drop_table( $migration->get_schema(), '' );
 			}
 

--- a/src/Migration_Seeder.php
+++ b/src/Migration_Seeder.php
@@ -68,7 +68,7 @@ class Migration_Seeder {
 	protected function insert_seed( Schema $schema, array $seed ): int {
 		// Get format for each column based on the type.
 		$format = array_map(
-			function( string $column_name ) use ( $schema ): string {
+			function ( string $column_name ) use ( $schema ): string {
 				return $this->column_type( $schema, $column_name );
 			},
 			array_keys( $seed )
@@ -82,6 +82,7 @@ class Migration_Seeder {
 
 		// Check any errors inserting.
 		if ( $this->wpdb->last_error !== '' ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- internal exception message.
 			throw Migration_Exception::failed_to_insert_seed( $schema, $this->wpdb->last_error );
 		}
 
@@ -101,6 +102,7 @@ class Migration_Seeder {
 
 		// If colum doesnt exist, thorw exception.
 		if ( ! array_key_exists( $column, $schema_columns ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- internal exception message.
 			throw Migration_Exception::seed_column_doesnt_exist( $schema, $column );
 		}
 


### PR DESCRIPTION
- composer.json: require PHP 8.0+, phpstan 2.x, phpstan-wordpress 2.x, WP 6.9 test deps. table_builder stays on 1.2.*.
- Replace WP 5.9/6.0/6.1 workflows with WP 6.6-6.9, PHP 8.0-8.4, 10-DB matrix (mysql:9, 8.4, 8.0 + mariadb 12, 11.8, 11.4, 11.2, 11.0, 10.11, 10.6). WP_6_9 uploads coverage to Codecov.
- Add standard .scrutinizer.yml.
- phpcs: add PSR12.Files.FileHeader.IncorrectOrder exclude.
- Source: phpcbf auto-fixes (brace/spacing), inline phpcs:ignore for ExceptionNotEscaped on throw statements, expand a short ternary in Migration_Log.
- README: https badges, new WP test badges, refreshed tested-against block, changelog entry for 1.0.5.