### PR TITLE
fix(ci): narrow phpunit to ^9.6 and emit clover from composer coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^2.0",
         "szepeviktor/phpstan-wordpress": "^2.0",
         "php-stubs/wordpress-stubs": "6.9.*",
@@ -42,7 +42,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit --colors=always --testdox --coverage-clover clover.xml",
-        "coverage": "vendor/bin/phpunit --colors=always --testdox --coverage-html coverage-report",
+        "coverage": "vendor/bin/phpunit --colors=always --testdox --coverage-html coverage-report --coverage-clover clover.xml",
         "analyse": "vendor/bin/phpstan analyse src -l8",
         "sniff": "./vendor/bin/phpcs src/ -v",
         "all": "composer coverage && composer analyse && composer sniff"


### PR DESCRIPTION
CI resolver was failing on 'composer update --no-cache' because the ^8.0 || ^9.0 phpunit range overlapped packagist security advisories (PKSA-5jz8-6tcw-pbk4, PKSA-z3gr-8qht-p93v) and composer refused to load the affected versions. Locally the resolver found 9.6.34 anyway, but the CI resolver path differed and errored out.

Narrow to ^9.6 — we dropped PHP 7.x when we required PHP 8.0+, so phpunit 8.x is no longer useful, and yoast/phpunit-polyfills already requires ^9.5.27 transitively.

While in composer.json, fix the 'coverage' script to emit clover.xml explicitly. The <logging><log coverage-clover> block in phpunit.xml.dist uses a PHPUnit 9-deprecated schema that emits on our local devilbox but is skipped on the GitHub Actions runner, so the codecov upload step found 0 files to upload.